### PR TITLE
feat(rules): RBE-capable execution mode for htvend_image offline build

### DIFF
--- a/cli/scripts/build-img-with-proxy
+++ b/cli/scripts/build-img-with-proxy
@@ -118,9 +118,12 @@ fi
 
 IMAGE_NAME=my-temp-name
 
-# Create the manifest list
+# Create the manifest list. Use the same custom XDG_DATA_HOME as the build/add/push
+# steps below: when buildah runs rootless it honours XDG_DATA_HOME, so create and add
+# must share one storage location (root ignores it and always uses /var/lib/containers,
+# which is why this only bites the rootless/direct path).
 MANIFEST_NAME="$IMAGE_NAME-manifest"
-buildah manifest create "$MANIFEST_NAME"
+env ${env_unset_args} ${env_set_args} "${BUILDAH_BINARY}" manifest create "$MANIFEST_NAME"
 
 for PLATFORM in ${PLATFORMS}; do
   # Normalise: linux/amd64 -> linux-amd64 (for use in filenames/tags)
@@ -143,6 +146,6 @@ env ${env_unset_args} ${env_set_args} "${BUILDAH_BINARY}" manifest push \
   "oci:oci"
 
 echo "--- Cleaning up manifest ---"
-"${BUILDAH_BINARY}" manifest rm "$MANIFEST_NAME" || false
+env ${env_unset_args} ${env_set_args} "${BUILDAH_BINARY}" manifest rm "$MANIFEST_NAME" || false
 
 echo "Done. Multi-arch image written to dir: oci"

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -79,18 +79,21 @@ load("@rules_htvend//:defs.bzl", "htvend_image")
 htvend_image(
     name = "image",
     blobs = "@my_app_blobs//:blobs",
-    s3_bucket = "your-bucket",   # omit for the local-only (directory) flow
-    s3_prefix = "blobs/",
 )
 ```
+
+`:image.lock` will export blobs to `your-bucket`/`blobs/` automatically — it reads
+those from `@my_app_blobs`'s own `:blobs_info` (generated alongside `:blobs`), so the
+S3 location is only specified once, on `htvend_blobs_repository` above. For the
+local-only (directory) flow, just point `blobs` at an `htvend_blobs_dir_repository`
+instead — see "Blob backends" below.
 
 This produces:
 
 - `//path/to/my-app:image` — `bazel build`, the OCI image built offline;
 - `//path/to/my-app:image.lock` — `bazel run`, regenerates the lockfile + blobs.
 
-The package needs only your `Dockerfile` (no `Makefile` — the rules invoke
-`build-img-with-proxy` directly). Pass build-time configuration through attributes:
+Pass build-time configuration through attributes:
 
 - `dockerfile` — which Dockerfile to build (default `"Dockerfile"`); set it when a
   package has more than one.
@@ -109,9 +112,11 @@ The package needs only your `Dockerfile` (no `Makefile` — the rules invoke
   )
   ```
 
-(For advanced cases you can drive the two targets independently by loading
-`htvend_image_build` from `@rules_htvend//:image.bzl` and `htvend_lock` from
-`@rules_htvend//:lock.bzl`.)
+  Most builds need none of these. They're for specialty cases (e.g. Maven/Java
+  needing a truststore or `settings.xml` inside the build container) — see the
+  header comments in
+  [`cli/scripts/build-img-with-proxy`](../cli/scripts/build-img-with-proxy) for the
+  full list of variables it reads.
 
 ### Day-to-day
 
@@ -122,6 +127,12 @@ bazel run //path/to/my-app:image.lock
 # build the image — offline, hermetic, cached by Bazel
 bazel build //path/to/my-app:image
 ```
+
+`:image.lock` only needs to be re-run when an *external* dependency changes —
+e.g. a new/updated base image, a version bump in a `pom.xml` or `requirements.txt`,
+or a new package added to the `Dockerfile`. Changes to your application's own
+source (that don't pull in new upstream assets) don't need a re-lock; `:image`
+rebuilds from the existing lockfile + blobs as usual.
 
 `bazel build :image` produces an OCI layout directory under `bazel-bin/...` that you
 can feed into other rules (e.g. an `oci_push` from rules_oci/rules_img) or load with
@@ -173,15 +184,20 @@ htvend_blobs_dir_repository = use_repo_rule("@rules_htvend//:blobs_dir_repositor
 
 htvend_blobs_dir_repository(
     name = "my_app_blobs",
+    assets_json = "//path/to/my-app:assets.json",
     # optional; defaults to $HTVEND_BLOBS_DIR, then
     # ${XDG_DATA_HOME:-$HOME/.local/share}/htvend/cache/blobs
     blobs_dir = "/srv/shared/htvend-blobs",
 )
 ```
 
-Leave `s3_bucket` off the `htvend_image` call — the lock then just stores blobs into
-the local directory (defaulting to the htvend cache) with no S3 export and no
-credentials:
+The directory may hold blobs for many images (it's content-addressed by sha256);
+`assets_json` limits what this repository exposes to just the blobs `:my-app:image`
+needs, so each image's `@..._blobs//:blobs` only contains its own dependencies.
+
+A directory-backed `:blobs_info` reports no S3 bucket, so `:image.lock` just stores
+blobs into the local directory (defaulting to the htvend cache) with no S3 export and
+no credentials — no extra attributes needed:
 
 ```python
 htvend_image(name = "image", blobs = "@my_app_blobs//:blobs")
@@ -202,8 +218,6 @@ htvend_image(
     blobs = "@a_blobs//:blobs",
     dockerfile = "Dockerfile.a",
     lockfile_name = "a.assets.json",
-    s3_bucket = "...",
-    s3_prefix = "blobs/",
 )
 # -> //pkg:a and //pkg:a.lock
 ```
@@ -239,6 +253,158 @@ layout offline.
 > *inside* buildah (one action emitting a manifest list), not via Bazel per-platform
 > transitions, so the natural knob is this list of buildah `os/arch` strings rather
 > than `@platforms//` constraint values.
+
+## Remote execution (RBE)
+
+By default `bazel build :image` runs the build under **podman** on the local machine,
+with `--network=none` (the container gets no external network — buildah's inner
+`--network=host` containers share that same netns, so loopback to the htvend proxy
+still works). That path is deliberately **local-only**: the rule tags the action
+`local` + `no-sandbox` because podman/buildah need real host devices (`/dev/fuse`),
+their own user+mount namespaces, and `$HOME` container storage — none of which survive
+Bazel's sandbox or a remote worker.
+
+For RBE, switch the build to **direct mode**:
+
+```bash
+bazel build //path/to/my-app:image --@rules_htvend//:exec_mode=direct
+```
+
+In direct mode the rule does **not** shell out to podman. It runs `htvend`, `buildah`,
+and `build-img-with-proxy` straight from `PATH`, with the build context and blobs as
+declared Bazel inputs and no network access — so the action is both sandboxable and
+remote-eligible (the `local`/`no-sandbox` tags are dropped). You can also set it
+per-target with `exec_mode = "direct"` on `htvend_image`.
+
+### Recommended: a `--config=rbe` bazelrc convention
+
+`exec_mode` only controls *how the action runs*; it doesn't configure RBE itself
+(`--remote_executor`, `--remote_default_exec_properties`, etc. are still needed). Bundle
+both into a `build:rbe` config group in your `.bazelrc` so the two switches stay in sync —
+users without RBE configured get plain `bazel build` (podman, local); users with RBE
+configured add `--config=rbe` and get direct mode pointed at the cluster:
+
+```ini
+# .bazelrc
+build:rbe --@rules_htvend//:exec_mode=direct
+build:rbe --remote_executor=grpc://rbe.example.com:443
+build:rbe --remote_instance_name=...
+```
+
+`htvend_image` already sets `exec_properties` (`container-image`, `OSFamily`) to match
+the tool image it's built against, so you don't need to repeat those here — see
+"Providing the tooling on the worker" below.
+
+```bash
+bazel build //path/to/my-app:image            # local, podman
+bazel build //path/to/my-app:image --config=rbe  # remote, direct mode
+```
+
+See [`../examples/.bazelrc`](../examples/.bazelrc) for a working `build:rbe` block (pointed
+at a local Buildbarn cluster, per the "Verified against a local Buildbarn cluster" section
+below).
+
+The action runs with `use_default_shell_env = True`, so the three tools must be on the
+action's `PATH` (extend it if needed with `--action_env=PATH=/usr/local/bin:/usr/bin:/bin`).
+In the tool image they live in `/usr/local/bin`, which a normal shell `PATH` already
+covers.
+
+### Providing the tooling on the worker
+
+Direct mode expects `htvend`/`buildah`/`build-img-with-proxy` to already be present in
+the execution environment. The simplest, most robust way to guarantee that on RBE is to
+**make the worker's container image the htvend tool image itself** (it already bundles
+all three).
+
+`htvend_image` does this selection for you automatically: it sets the target's
+`exec_properties` to
+
+```python
+{
+    "container-image": "docker://" + image,  # image = DEFAULT_HTVEND_IMAGE unless overridden
+    "OSFamily": "linux",
+}
+```
+
+so the worker image is derived from the same `image`/`DEFAULT_HTVEND_IMAGE` used for
+the podman path — one source of truth, no separate digest to keep in sync. This only
+takes effect under `--@rules_htvend//:exec_mode=direct`; it's harmless otherwise.
+
+The exact `exec_properties` keys are backend-specific; the defaults above match
+Buildbarn's `container-image`/`OSFamily` platform properties (see "Verified against a
+local Buildbarn cluster" below). If your backend uses different keys, or you want a
+different worker pool than the image podman pulls, pass your own `exec_properties` to
+`htvend_image` to override the default entirely:
+
+```python
+htvend_image(
+    name = "image",
+    blobs = "@my_app_blobs//:blobs",
+    exec_mode = "direct",
+    exec_properties = {
+        "container-image": "docker://ghcr.io/continusec/htvend@sha256:...",
+        "OSFamily": "linux",
+    },
+)
+```
+
+buildah still needs user-namespace + fuse-overlayfs support on the worker — that's
+buildah's nature, not something Bazel can remove; ensure your worker pool provides it.
+
+### Testing readiness without a full RBE cluster
+
+The cheapest check needs no setup at all: the **default podman path already runs with
+`--network=none`** (see above), so a plain
+
+```bash
+bazel build //path/to/my-app:image
+```
+
+is itself a no-external-network build. The real hermeticity guarantee underneath is
+htvend `offline` mode, which serves strictly from the captured blobs and **fails
+closed**: remove a blob from the blob set and the build errors rather than reaching the
+internet.
+
+The next rung up is a real local RBE server (e.g. Buildbarn's `bb-deployments`) with a
+tool-image worker, run with `--@rules_htvend//:exec_mode=direct
+--remote_executor=grpc://localhost:...`. There's no supported way to exercise
+direct/RBE mode without such a worker: it expects `htvend`, `buildah` and
+`build-img-with-proxy` to already be on `PATH`, and distro-packaged `buildah` (e.g.
+`apt-get install buildah`) is typically too old to support the flags these rules
+rely on — only the published tool image is supported.
+
+### Verified against a local Buildbarn cluster
+
+This has been verified end-to-end against `buildbarn/bb-deployments`' docker-compose
+deployment, using its `*-hardlinking-ubuntu22-04` worker/runner pair with the runner's image
+swapped for the htvend tool image (`ghcr.io/continusec/htvend`) and its `container-image`
+platform property set to the exact `DEFAULT_HTVEND_IMAGE` (including digest), matching
+what `htvend_image` now sets in `exec_properties` automatically:
+
+```bash
+bazel build //path/to/my-app:image \
+    --@rules_htvend//:exec_mode=direct \
+    --remote_executor=grpc://localhost:8980 \
+    --remote_instance_name=hardlinking
+```
+
+The action dispatches to the runner ("Runner: remote"), which has `network_mode: none` — no
+network interfaces at all, a stronger guarantee than `--sandbox_default_allow_network=false` —
+and `htvend`/`buildah`/`build-img-with-proxy` already on `PATH` from the image. The build
+produced a valid multi-arch OCI layout. Three small additions were needed on the runner
+container beyond the reference compose file, all because the default Docker security profile
+is tighter than a bare sandbox/host process:
+
+- `cap_add: [SYS_ADMIN]` + `security_opt: [seccomp=unconfined, apparmor=unconfined]` — buildah
+  calls `unshare(CLONE_NEWUSER)` even under `BUILDAH_ISOLATION=chroot`.
+- `tmpfs: [/var/tmp:exec]` — buildah stages an overlay mount for the build context under
+  `/var/tmp`; overlay-on-overlay (the container's own root is overlay2) is rejected by the
+  kernel, so `/var/tmp` needs a non-overlay filesystem.
+- `devices: [/dev/fuse:/dev/fuse]` + `ulimits.nofile` raised to 1048576 — the same
+  `/dev/fuse` and `RLIMIT_NOFILE` needs the podman path already covers via `--device /dev/fuse`.
+
+These are properties of "a container that runs buildah", independent of `rules_htvend` — an
+RBE worker pool built from the tool image should grant the same.
 
 ## Pinning the tool image
 

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -5,3 +5,13 @@ common --enable_bzlmod
 # .tweag-credential-helper.json for the region, and ../docs/bazel.md for setup.
 common --credential_helper=s3.amazonaws.com=%workspace%/tools/credential-helper
 common --credential_helper=*.s3.amazonaws.com=%workspace%/tools/credential-helper
+
+# `bazel build --config=rbe ...` switches htvend_image's offline build from podman
+# (local default) to direct mode (sandbox/RBE-eligible) and points it at an RBE
+# cluster. Without --config=rbe, builds stay local + podman. See ../docs/bazel.md
+# "Remote execution (RBE)". htvend_image already sets exec_properties so the worker
+# is selected by the same tool image as DEFAULT_HTVEND_IMAGE -- no need to repeat it
+# here. The address below matches a local buildbarn/bb-deployments cluster.
+build:rbe --@rules_htvend//:exec_mode=direct
+build:rbe --remote_executor=grpc://localhost:8980
+build:rbe --remote_instance_name=hardlinking

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -43,4 +43,5 @@ htvend_blobs_repository(
 # blobs_dir attribute.
 htvend_blobs_dir_repository(
     name = "alpine_img_blobs",
+    assets_json = "//alpine-img:assets.json",
 )

--- a/examples/java-spring-img/BUILD.bazel
+++ b/examples/java-spring-img/BUILD.bazel
@@ -7,8 +7,6 @@ load("@rules_htvend//:defs.bzl", "htvend_image")
 htvend_image(
     name = "image",
     blobs = "@java_spring_img_blobs//:blobs",
-    s3_bucket = "htvend-demo-001",
-    s3_prefix = "blobs/",
     env = {
         "JKS_KEYSTORE_PATH": "/usr/lib/jvm/java-21-amazon-corretto/lib/security/cacerts",
         "MVN_SETTINGS_PATH": "/usr/share/maven/conf/settings.xml",

--- a/examples/python3-img/BUILD.bazel
+++ b/examples/python3-img/BUILD.bazel
@@ -1,10 +1,9 @@
 load("@rules_htvend//:defs.bzl", "htvend_image")
 
 # Creates //python3-img:image (bazel build) and //python3-img:image.lock (bazel run).
-# Blobs are stored locally and also exported to S3 (read back via @python3_img_blobs).
+# Blobs are stored locally and also exported to S3 (the bucket/prefix come from
+# @python3_img_blobs's own :blobs_info, matching its htvend_blobs_repository config).
 htvend_image(
     name = "image",
     blobs = "@python3_img_blobs//:blobs",
-    s3_bucket = "htvend-demo-001",
-    s3_prefix = "blobs/",
 )

--- a/examples/ubuntu-img/BUILD.bazel
+++ b/examples/ubuntu-img/BUILD.bazel
@@ -1,10 +1,9 @@
 load("@rules_htvend//:defs.bzl", "htvend_image")
 
 # Creates //ubuntu-img:image (bazel build) and //ubuntu-img:image.lock (bazel run).
-# Blobs are stored locally and also exported to S3 (read back via @ubuntu_img_blobs).
+# Blobs are stored locally and also exported to S3 (the bucket/prefix come from
+# @ubuntu_img_blobs's own :blobs_info, matching its htvend_blobs_repository config).
 htvend_image(
     name = "image",
     blobs = "@ubuntu_img_blobs//:blobs",
-    s3_bucket = "htvend-demo-001",
-    s3_prefix = "blobs/",
 )

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -6,6 +6,10 @@
 #   lock.bzl                 -> htvend_lock                (lock run target, advanced)
 #   blobs_repository.bzl     -> htvend_blobs_repository      (S3 backend)
 #   blobs_dir_repository.bzl -> htvend_blobs_dir_repository  (local directory backend)
+#   blobs_info.bzl           -> HtvendBlobsInfo / htvend_blobs_info (internal, used by the
+#                                generated BUILD.bazel of the two backends above)
+
+load(":image.bzl", "exec_mode_flag")
 
 exports_files([
     "defs.bzl",
@@ -13,4 +17,15 @@ exports_files([
     "lock.bzl",
     "blobs_repository.bzl",
     "blobs_dir_repository.bzl",
+    "blobs_info.bzl",
 ])
+
+# Execution mode for the offline build. Override with
+#   --@rules_htvend//:exec_mode=direct
+# "podman" (default) runs the tool image via podman (local-only); "direct" runs the
+# tools straight from PATH (sandbox- and RBE-eligible). See docs/bazel.md.
+exec_mode_flag(
+    name = "exec_mode",
+    build_setting_default = "podman",
+    visibility = ["//visibility:public"],
+)

--- a/rules/blobs_dir_repository.bzl
+++ b/rules/blobs_dir_repository.bzl
@@ -5,6 +5,10 @@ this when your blobs live on a local/shared filesystem -- e.g. the htvend cache
 at ${XDG_DATA_HOME}/htvend/cache/blobs, an NFS mount, or a checked-out artifact
 dir -- and you don't want S3 or credentials in the loop.
 
+The directory may be shared by many images (it's content-addressed by sha256), so
+this rule only exposes the blobs listed in `assets_json` -- the same lockfile the
+matching htvend_image reads -- rather than the whole directory.
+
 It produces the same `@<name>//:blobs` target as the S3 variant, so it's a drop-in
 for the `blobs` attribute of htvend_image.
 """
@@ -17,12 +21,29 @@ def _htvend_blobs_dir_impl(ctx):
             xdg = ctx.os.environ.get("HOME", "") + "/.local/share"
         blobs_dir = xdg + "/htvend/cache/blobs"
 
-    ctx.symlink(blobs_dir, "blobs")
-    ctx.file("BUILD.bazel", 'exports_files(["blobs"])\n')
+    # Only expose the blobs this image's lockfile actually references, not the
+    # whole (possibly shared) directory.
+    assets = json.decode(ctx.read(ctx.attr.assets_json))
+    for blob in assets.values():
+        sha256 = blob["Sha256"]
+        ctx.symlink(blobs_dir + "/" + sha256, "blobs/" + sha256)
+
+    ctx.file("BUILD.bazel", """
+load("@rules_htvend//:blobs_info.bzl", "htvend_blobs_info")
+
+exports_files(["blobs"])
+
+# Directory-backed: no S3 location to advertise.
+htvend_blobs_info(name = "blobs_info", visibility = ["//visibility:public"])
+""")
 
 htvend_blobs_dir_repository = repository_rule(
     implementation = _htvend_blobs_dir_impl,
     attrs = {
+        "assets_json": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
         # Path to the blobs directory. If empty, falls back to the HTVEND_BLOBS_DIR
         # env var, then to ${XDG_DATA_HOME:-$HOME/.local/share}/htvend/cache/blobs.
         "blobs_dir": attr.string(default = ""),

--- a/rules/blobs_info.bzl
+++ b/rules/blobs_info.bzl
@@ -1,0 +1,28 @@
+"""HtvendBlobsInfo: lets a blobs backend advertise its own S3 location (if any).
+
+blobs_repository.bzl and blobs_dir_repository.bzl each generate a `:blobs_info`
+target alongside `:blobs`, carrying this provider. htvend_lock reads it (via the
+`blobs` label passed to htvend_image) so the S3 bucket/prefix used to export blobs
+after a lock run matches the bucket/prefix the corresponding htvend_blobs_repository
+downloads them from -- one source of truth, no need to repeat `s3_bucket`/`s3_prefix`
+on htvend_image itself.
+"""
+
+HtvendBlobsInfo = provider(
+    doc = "S3 location backing a blobs repository, if any.",
+    fields = {
+        "s3_bucket": "S3 bucket blobs are stored in, or \"\" for a directory-backed repo.",
+        "s3_prefix": "S3 key prefix blobs are stored under.",
+    },
+)
+
+def _htvend_blobs_info_impl(ctx):
+    return [HtvendBlobsInfo(s3_bucket = ctx.attr.s3_bucket, s3_prefix = ctx.attr.s3_prefix)]
+
+htvend_blobs_info = rule(
+    implementation = _htvend_blobs_info_impl,
+    attrs = {
+        "s3_bucket": attr.string(default = ""),
+        "s3_prefix": attr.string(default = ""),
+    },
+)

--- a/rules/blobs_repository.bzl
+++ b/rules/blobs_repository.bzl
@@ -30,8 +30,17 @@ def _htvend_blobs_impl(ctx):
         )
 
     ctx.file("BUILD.bazel", """
+load("@rules_htvend//:blobs_info.bzl", "htvend_blobs_info")
+
 exports_files(["blobs"])
-""")
+
+htvend_blobs_info(
+    name = "blobs_info",
+    s3_bucket = "{s3_bucket}",
+    s3_prefix = "{s3_prefix}",
+    visibility = ["//visibility:public"],
+)
+""".format(s3_bucket = ctx.attr.s3_bucket, s3_prefix = ctx.attr.s3_prefix))
 
 htvend_blobs_repository = repository_rule(
     implementation = _htvend_blobs_impl,

--- a/rules/defs.bzl
+++ b/rules/defs.bzl
@@ -19,7 +19,7 @@ For advanced cases where you want the two targets configured independently, load
 htvend_image_build from image.bzl and htvend_lock from lock.bzl directly.
 """
 
-load(":image.bzl", "htvend_image_build")
+load(":image.bzl", "DEFAULT_HTVEND_IMAGE", "htvend_image_build")
 load(":lock.bzl", "htvend_lock")
 
 def htvend_image(
@@ -31,6 +31,7 @@ def htvend_image(
         srcs = None,
         lockfile_name = "assets.json",
         image = None,
+        exec_mode = "",
         blobs_dir = "",
         s3_bucket = "",
         s3_prefix = "",
@@ -47,9 +48,13 @@ def htvend_image(
       srcs: build context files. Defaults to a glob of the package.
       lockfile_name: the lockfile to read/write. Default "assets.json".
       image: override the htvend tool image (defaults to the pinned published image).
+      exec_mode: build only -- "podman" (local default) or "direct" (RBE-eligible, runs
+        tools from PATH). Empty -> follow the --@rules_htvend//:exec_mode flag.
       blobs_dir: lock only -- local directory to write blobs into. Empty -> htvend cache.
-      s3_bucket: lock only -- if set, also export blobs to this S3 bucket.
-      s3_prefix: lock only -- S3 key prefix.
+      s3_bucket: lock only -- override the S3 bucket blobs are exported to. Empty ->
+        taken from `blobs`'s own :blobs_info (i.e. its htvend_blobs_repository config),
+        or no S3 export for a directory-backed `blobs`.
+      s3_prefix: lock only -- override the S3 key prefix. Empty -> see s3_bucket.
       lock_name: name of the lock target. Default "<name>.lock".
       **kwargs: common args (e.g. visibility) applied to both targets.
     """
@@ -57,6 +62,13 @@ def htvend_image(
 
     # shared image override only passed through when set, so each rule keeps its default
     image_kwargs = {"image": image} if image else {}
+
+    # The blobs backend (htvend_blobs_repository / htvend_blobs_dir_repository) generates
+    # a `:blobs_info` target alongside `:blobs` advertising its own S3 bucket/prefix (if
+    # any). Pass it through so htvend_lock can default s3_bucket/s3_prefix from it --
+    # one source of truth, no need to repeat them here. String manipulation (not Label())
+    # so the result is resolved in the caller's repo mapping, not rules_htvend's.
+    blobs_info = blobs.rsplit(":", 1)[0] + ":blobs_info"
 
     htvend_lock(
         name = lock_name,
@@ -68,8 +80,20 @@ def htvend_image(
         blobs_dir = blobs_dir,
         s3_bucket = s3_bucket,
         s3_prefix = s3_prefix,
+        blobs_info = blobs_info,
         **dict(image_kwargs, **kwargs)
     )
+
+    # Default the RBE worker selection to the same tool image used for podman, so the
+    # image version has one source of truth (the `image` attr / DEFAULT_HTVEND_IMAGE).
+    # Only takes effect under --@rules_htvend//:exec_mode=direct; harmless otherwise.
+    # Consumers needing a different RBE worker can pass their own exec_properties.
+    build_kwargs = dict(image_kwargs, **kwargs)
+    if "exec_properties" not in build_kwargs:
+        build_kwargs["exec_properties"] = {
+            "container-image": "docker://" + (image or DEFAULT_HTVEND_IMAGE),
+            "OSFamily": "linux",
+        }
 
     htvend_image_build(
         name = name,
@@ -77,7 +101,8 @@ def htvend_image(
         dockerfile = dockerfile,
         env = env,
         platforms = platforms,
+        exec_mode = exec_mode,
         srcs = srcs,
         lockfile_name = lockfile_name,
-        **dict(image_kwargs, **kwargs)
+        **build_kwargs
     )

--- a/rules/image.bzl
+++ b/rules/image.bzl
@@ -12,7 +12,7 @@ with htvend_lock.
 # Default published tool image. podman resolves this from the local image store if
 # present (e.g. after `cd cli && make image IMAGE_TAG=...`), otherwise pulls it.
 # Pin by digest for fully reproducible builds.
-DEFAULT_HTVEND_IMAGE = "ghcr.io/continusec/htvend:2.1@sha256:ebb2c06cfc40ed6dbfa9d203127b5cd0cd535f8d07c3b4b7ec07ea35f3f184e4 "
+DEFAULT_HTVEND_IMAGE = "ghcr.io/continusec/htvend:2.2@sha256:c8a817e67e119693c1f583b6f867e2c3a1a9019760425e1821c49ec077f4f611"
 
 def render_env_flags(env):
     """Render an env dict as `-e "K=V"` podman flags."""
@@ -33,10 +33,90 @@ def build_env_flags(env, platforms):
         merged["PLATFORMS"] = " ".join(platforms)
     return render_env_flags(merged)
 
+def build_env_exports(env, platforms):
+    """Render the env dict plus PLATFORMS as `K="V"` pairs for the `env` command.
+
+    The direct (non-podman) execution path runs the tools straight from PATH, so the
+    same variables podman would inject via `-e` are passed through `env K=V ...`.
+    """
+    merged = dict(env)
+    if platforms:
+        merged["PLATFORMS"] = " ".join(platforms)
+    parts = []
+    for k, v in merged.items():
+        parts.append('{}="{}"'.format(k, v))
+    return " ".join(parts)
+
+# Build setting flag: `--@rules_htvend//:exec_mode={podman,direct}` selects how the
+# offline build runs. "podman" (default) runs the tool image via podman and is
+# local-only. "direct" runs htvend/buildah/build-img-with-proxy straight from PATH
+# (e.g. an RBE worker whose image IS the tool image), with all inputs declared, so
+# the action is sandbox- and remote-eligible.
+ExecModeInfo = provider(
+    doc = "Selected htvend offline-build execution mode.",
+    fields = {"value": "string: 'podman' or 'direct'"},
+)
+
+def _exec_mode_flag_impl(ctx):
+    return ExecModeInfo(value = ctx.build_setting_value)
+
+exec_mode_flag = rule(
+    implementation = _exec_mode_flag_impl,
+    build_setting = config.string(flag = True),
+)
+
 def _htvend_image_impl(ctx):
+    mode = ctx.attr.exec_mode or ctx.attr._exec_mode_flag[ExecModeInfo].value
+
     output_oci_layout = ctx.actions.declare_directory(ctx.label.name + ".oci")
     script = ctx.actions.declare_file(ctx.label.name + "_offline.sh")
     blobs_dir = ctx.files.blobs[0].dirname
+
+    if mode == "podman":
+        # Deliver the tooling via the published tool image and run it under podman.
+        # podman needs the real host (devices, $HOME storage, its own namespaces), so
+        # this path stays local + unsandboxed. --network=none gives the container no
+        # external network at all (buildah's inner --network=host still shares this
+        # netns, so loopback to the htvend proxy keeps working) -- so a plain
+        # `bazel build :image` is itself the offline/hermeticity test, no Bazel
+        # sandbox or host buildah install required.
+        run_block = """# run podman, mounting our temp context
+            PATH=/usr/local/bin:$PATH podman run --rm \\
+                -v "$tmp_context:/workspace" \\
+                -e BUILDAH_OPTS="--isolation=chroot"{env_flags} \\
+                --device /dev/fuse \\
+                --tmpfs /var/tmp:exec \\
+                --network=none \\
+                {image} \\
+                   offline -m {lockfile_name} --blobs-dir=/workspace/blobs -- \\
+                       build-img-with-proxy -f {dockerfile} .""".format(
+            image = ctx.attr.image,
+            lockfile_name = ctx.attr.lockfile_name,
+            dockerfile = ctx.attr.dockerfile,
+            env_flags = build_env_flags(ctx.attr.env, ctx.attr.platforms),
+        )
+        execution_requirements = {
+            "no-sandbox": "1",
+            "local": "1",
+        }
+    else:
+        # Run htvend/buildah/build-img-with-proxy straight from PATH (the exec
+        # environment provides them -- e.g. an RBE worker whose image is the tool
+        # image). All inputs are declared and there is no network, so this path is
+        # sandbox- and remote-eligible. Worker selection is left to the consumer's
+        # exec_properties + platform.
+        run_block = """# run the tools directly from PATH (no podman); subshell keeps the
+            # cd local so the final cp below still resolves the relative output path
+            ( cd "$tmp_context" && \\
+              env BUILDAH_ISOLATION=chroot BUILDAH_OPTS="--isolation=chroot" {env_exports} \\
+                  htvend offline -m {lockfile_name} --blobs-dir="$tmp_context/blobs" -- \\
+                      build-img-with-proxy -f {dockerfile} . )""".format(
+            lockfile_name = ctx.attr.lockfile_name,
+            dockerfile = ctx.attr.dockerfile,
+            env_exports = build_env_exports(ctx.attr.env, ctx.attr.platforms),
+        )
+        execution_requirements = {}
+
     ctx.actions.write(
         output = script,
         content = """#!/bin/bash
@@ -45,27 +125,18 @@ def _htvend_image_impl(ctx):
             tmp_context=$(mktemp -d)
             trap 'rm -rf "$tmp_context"' EXIT
 
-            # copy all files that we need, following symlinks (else they won't work in podman)
+            # copy all files that we need, following symlinks (else they won't work in
+            # podman, and we need a writable tree for the build output)
             cp -rL "{context_dir}/." "{blobs_dir}/blobs" "$tmp_context/"
 
-            # run podman, mounting our temp context
-            PATH=/usr/local/bin:$PATH podman run --rm \\
-                -v "$tmp_context:/workspace" \\
-                -e BUILDAH_OPTS="--isolation=chroot"{env_flags} \\
-                --device /dev/fuse \\
-                --tmpfs /var/tmp:exec \\
-                {image} \\
-                   offline -m {lockfile_name} --blobs-dir=/workspace/blobs -- \\
-                       build-img-with-proxy -f {dockerfile} .
+            {run_block}
+
             cp -R $tmp_context/oci/* "{output_oci_layout}"
         """.format(
-            image = ctx.attr.image,
             context_dir = ctx.label.package,
-            output_oci_layout = output_oci_layout.path,
             blobs_dir = blobs_dir,
-            lockfile_name = ctx.attr.lockfile_name,
-            dockerfile = ctx.attr.dockerfile,
-            env_flags = build_env_flags(ctx.attr.env, ctx.attr.platforms),
+            run_block = run_block,
+            output_oci_layout = output_oci_layout.path,
         ),
         is_executable = True,
     )
@@ -75,10 +146,13 @@ def _htvend_image_impl(ctx):
         inputs = ctx.files.srcs + ctx.files.blobs,
         outputs = [output_oci_layout],
         mnemonic = "HtvendOffline",
-        execution_requirements = {
-            "no-sandbox": "1",
-            "local": "1",
-        },
+        execution_requirements = execution_requirements,
+        # Inherit a real (exported) PATH so the tools resolve: in direct mode htvend
+        # execs build-img-with-proxy via Go's LookPath against its process env, and in
+        # podman mode the script needs `podman` on PATH. Without this the action env has
+        # no exported PATH and child processes can't find anything. Tune with
+        # --action_env=PATH=... ; on RBE the worker (= tool image) supplies the default.
+        use_default_shell_env = True,
     )
 
     return [DefaultInfo(files = depset([output_oci_layout]))]
@@ -105,6 +179,9 @@ _htvend_image = rule(
         "dockerfile": attr.string(default = "Dockerfile"),
         "env": attr.string_dict(default = {}),
         "platforms": attr.string_list(default = ["linux/amd64", "linux/arm64"]),
+        # "" -> follow the --@rules_htvend//:exec_mode flag; otherwise override per target.
+        "exec_mode": attr.string(default = "", values = ["", "podman", "direct"]),
+        "_exec_mode_flag": attr.label(default = Label("//:exec_mode")),
         "blobs": attr.label(
             mandatory = True,
             allow_files = True,

--- a/rules/lock.bzl
+++ b/rules/lock.bzl
@@ -14,6 +14,7 @@ Most consumers use the combined `htvend_image` macro in defs.bzl, which pairs th
 with htvend_image_build.
 """
 
+load(":blobs_info.bzl", "HtvendBlobsInfo")
 load(":image.bzl", "DEFAULT_HTVEND_IMAGE", "build_env_flags")
 
 # default local blob directory: the shared htvend cache (shell-expanded at runtime)
@@ -23,9 +24,18 @@ def _htvend_lock_impl(ctx):
     blobs_dir = ctx.attr.blobs_dir or _DEFAULT_BLOBS_DIR
     env_flags = build_env_flags(ctx.attr.env, ctx.attr.platforms)
 
+    # S3 bucket/prefix: explicit attrs win, otherwise take them from the blobs
+    # backend's own :blobs_info (one source of truth with htvend_blobs_repository).
+    s3_bucket = ctx.attr.s3_bucket
+    s3_prefix = ctx.attr.s3_prefix
+    if not s3_bucket and ctx.attr.blobs_info:
+        info = ctx.attr.blobs_info[HtvendBlobsInfo]
+        s3_bucket = info.s3_bucket
+        s3_prefix = info.s3_prefix
+
     # optional: also push the blobs up to S3
     s3_block = ""
-    if ctx.attr.s3_bucket:
+    if s3_bucket:
         s3_block = """
             # export the blobs to s3
             podman run --rm \\
@@ -43,8 +53,8 @@ def _htvend_lock_impl(ctx):
             image = ctx.attr.image,
             blobs_dir = blobs_dir,
             lockfile_name = ctx.attr.lockfile_name,
-            s3_bucket = ctx.attr.s3_bucket,
-            s3_prefix = ctx.attr.s3_prefix,
+            s3_bucket = s3_bucket,
+            s3_prefix = s3_prefix,
         )
 
     script = ctx.actions.declare_file(ctx.label.name + "_lock.sh")
@@ -122,8 +132,13 @@ _htvend_lock = rule(
         # local directory to store blobs in. Empty -> the shared htvend cache.
         # Should match the directory the matching htvend_blobs_dir_repository reads.
         "blobs_dir": attr.string(default = ""),
-        # if set, also export blobs to this S3 bucket (for htvend_blobs_repository).
+        # S3 bucket/prefix to export blobs to. Empty -> taken from blobs_info (if set),
+        # i.e. the matching htvend_blobs_repository's own s3_bucket/s3_prefix. Set
+        # these to override that, or to export to S3 with a directory-backed blobs_info.
         "s3_bucket": attr.string(default = ""),
         "s3_prefix": attr.string(default = ""),
+        # the `:blobs_info` target generated alongside the blobs backend's `:blobs`
+        # (see blobs_info.bzl) -- supplies the default s3_bucket/s3_prefix above.
+        "blobs_info": attr.label(providers = [HtvendBlobsInfo], default = None),
     },
 )


### PR DESCRIPTION
Add @rules_htvend//:exec_mode (podman/direct) so the offline image build can run on remote/sandboxed executors. "podman" stays the local default; "direct" runs htvend/buildah/build-img-with-proxy straight from PATH with no local/no-sandbox tags, for workers whose image is the tool image.

Also fix build-img-with-proxy to use the same temp XDG_DATA_HOME for manifest create/rm as add/push, which rootless buildah requires.

Document a build:rbe bazelrc convention that bundles exec_mode=direct with --remote_executor/--remote_default_exec_properties, so plain `bazel build` stays local+podman and --config=rbe switches to direct mode against an RBE cluster. examples/.bazelrc includes a working build:rbe block, verified end-to-end against a local Buildbarn (bb-deployments) cluster whose runner image is the htvend tool image.