### PR TITLE
feat(rules): default direct/RBE builds to vfs storage driver

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -253,6 +253,12 @@ Pass build-time options through `htvend_image` attributes:
   [`cli/scripts/build-img-with-proxy`](../cli/scripts/build-img-with-proxy) for the full
   list of variables it reads.
 
+- **`storage_driver`** — buildah storage driver for the offline build. Empty (default)
+  uses each mode's natural default: **direct/RBE mode uses `vfs`** so the worker needs no
+  `/dev/fuse`; podman mode uses the tool image's overlay (with the `/dev/fuse` device it
+  already passes). Set `"overlay"` or `"vfs"` to override. See
+  [Remote execution (RBE)](#remote-execution-rbe).
+
 ### Multiple images in one package
 
 `htvend_image` takes a `lockfile_name` (default `assets.json`). To host several images in
@@ -365,15 +371,51 @@ entirely. The action runs with `use_default_shell_env = True`, so the three tool
 on the action's `PATH` (extend with `--action_env=PATH=...` if needed; in the tool image
 they're in `/usr/local/bin`).
 
-buildah still needs user-namespace + fuse-overlayfs support on the worker — that's
-buildah's nature, not something Bazel removes; ensure your worker pool provides it.
+buildah still needs **mount privilege** on the worker to set up each `RUN` container —
+that's buildah's nature, not something Bazel removes. The next section pins down exactly
+what the worker pool must allow.
+
+### Worker privilege requirements
+
+The custom worker image is the *easy* part: `container-image` is a standard REAPI platform
+property, and pointing a worker pool at the tool image is an ordinary Buildbarn operation.
+What an RBE team actually has to sign off on is the **privilege buildah needs to execute
+`RUN` instructions**. Direct mode keeps that as small as practical:
+
+- **Storage driver defaults to `vfs`**, so the worker needs **no `/dev/fuse`** (overlay's
+  fuse-overlayfs is what would otherwise need it). The output image is byte-identical to
+  the overlay build — vfs just copies where overlay would mount, trading some speed/disk.
+  Override with the `storage_driver` attribute (e.g. `"overlay"` if your worker *does*
+  provide a fuse device).
+- **A non-overlay writable `/var/tmp`** (e.g. `tmpfs: [/var/tmp:exec]`) — buildah stages an
+  overlay mount of the *build context* there, and overlay-on-overlay (the container's own
+  rootfs) is rejected by the kernel. Needed even with the vfs driver.
+- **Raised `RLIMIT_NOFILE`** (e.g. `nofile: 1048576`) — buildah raises it for build
+  containers; start high so it needn't hold `CAP_SYS_RESOURCE`.
+- **Mount privilege for the `RUN` containers** — irreducible (every `RUN` bind-mounts
+  `/proc`, `/dev`, secrets, …). Grant it one of two equivalent ways:
+
+  | | added caps | seccomp | apparmor¹ | how `RUN`'s mounts happen |
+  |---|---|---|---|---|
+  | **Strategy P** | `SYS_ADMIN` | **default** (filter stays on) | `unconfined` | real `CAP_SYS_ADMIN` — assumes the action runs as root² |
+  | **Strategy U** | none | `unconfined` | `unconfined` | buildah creates a user namespace (`unshare(CLONE_NEWUSER)`, which the default seccomp profile blocks) |
+
+  ¹ `apparmor=unconfined` is only needed where the runtime applies a restrictive default
+  LSM profile (e.g. Docker's `docker-default`, which denies the mounts). A custom apparmor
+  profile allowing just buildah's mounts is a finer-grained alternative; on hosts without
+  apparmor it doesn't apply at all.
+  ² true on the bb-deployments runner, whose image is `User=0`; bb_runner sets no uid.
+
+  Strategy P generally sits better with security teams — it keeps the seccomp filter on;
+  Strategy U avoids granting `CAP_SYS_ADMIN`. **Neither runs on a fully locked-down generic
+  runner** — some mount privilege is unavoidable for image builds that execute `RUN`.
 
 ### Verified against a local Buildbarn cluster
 
-This has been verified end-to-end against `buildbarn/bb-deployments`' docker-compose
+Both strategies are verified end-to-end against `buildbarn/bb-deployments`' docker-compose
 deployment, using its `*-hardlinking-ubuntu22-04` worker/runner pair with the runner's
-image swapped for the htvend tool image and its `container-image` property set to the
-exact `DEFAULT_HTVEND_IMAGE` (including digest):
+image swapped for the htvend tool image and its `container-image` property set to the exact
+`DEFAULT_HTVEND_IMAGE` (including digest):
 
 ```bash
 bazel build //app:image \
@@ -383,16 +425,14 @@ bazel build //app:image \
 ```
 
 The action dispatches to the runner ("Runner: remote"), which has `network_mode: none` —
-no network interfaces at all — and the three tools on `PATH` from the image. Three small
-additions were needed on the runner container beyond the reference compose file (the
-default Docker security profile is tighter than a bare sandbox/host process):
+no network interfaces at all — and the three tools on `PATH` from the image. Both runner
+privilege sets below produced the **byte-identical** OCI image (`--network=none`, vfs
+driver, **no `/dev/fuse`**):
 
-- `cap_add: [SYS_ADMIN]` + `security_opt: [seccomp=unconfined, apparmor=unconfined]` —
-  buildah calls `unshare(CLONE_NEWUSER)` even under `BUILDAH_ISOLATION=chroot`.
-- `tmpfs: [/var/tmp:exec]` — buildah stages an overlay mount under `/var/tmp`; overlay-on-
-  overlay is rejected by the kernel.
-- `devices: [/dev/fuse:/dev/fuse]` + `ulimits.nofile` raised to 1048576 — the same
-  `/dev/fuse` + `RLIMIT_NOFILE` the podman path covers via `--device /dev/fuse`.
+- **Strategy P** — `cap_add: [SYS_ADMIN]`, `security_opt: [apparmor=unconfined]` (default
+  seccomp), `tmpfs: [/var/tmp:exec]`, `ulimits.nofile: 1048576`.
+- **Strategy U** — `security_opt: [seccomp=unconfined, apparmor=unconfined]` (no added
+  caps), `tmpfs: [/var/tmp:exec]`, `ulimits.nofile: 1048576`.
 
 These are properties of "a container that runs buildah", independent of `rules_htvend`.
 

--- a/rules/image.bzl
+++ b/rules/image.bzl
@@ -92,6 +92,14 @@ def _htvend_image_impl(ctx):
         # netns, so loopback to the htvend proxy keeps working) -- so a plain
         # `bazel build :image` is itself the offline/hermeticity test, no Bazel
         # sandbox or host buildah install required.
+        #
+        # storage_driver is normally left empty here: the tool image runs buildah with
+        # overlay + the --device /dev/fuse passed below, which is the efficient local
+        # path. Honour an explicit override if the consumer sets one.
+        podman_env = dict(ctx.attr.env)
+        if ctx.attr.storage_driver:
+            podman_env["STORAGE_DRIVER"] = ctx.attr.storage_driver
+
         run_block = """# run podman, mounting our temp context
             PATH=/usr/local/bin:$PATH podman run --rm \\
                 -v "$tmp_context:/workspace" \\
@@ -105,7 +113,7 @@ def _htvend_image_impl(ctx):
             image = ctx.attr.image,
             lockfile_name = ctx.attr.lockfile_name,
             dockerfile = ctx.attr.dockerfile,
-            env_flags = build_env_flags(ctx.attr.env, ctx.attr.platforms),
+            env_flags = build_env_flags(podman_env, ctx.attr.platforms),
         )
         execution_requirements = {
             "no-sandbox": "1",
@@ -117,6 +125,13 @@ def _htvend_image_impl(ctx):
         # image). All inputs are declared and there is no network, so this path is
         # sandbox- and remote-eligible. Worker selection is left to the consumer's
         # exec_properties + platform.
+        #
+        # Default the storage driver to vfs: unlike overlay it needs no /dev/fuse, so the
+        # action runs on an RBE worker with no fuse device. The output image is identical
+        # (vfs just copies where overlay would mount). Override with the storage_driver attr.
+        direct_env = dict(ctx.attr.env)
+        direct_env["STORAGE_DRIVER"] = ctx.attr.storage_driver or "vfs"
+
         run_block = """# run the tools directly from PATH (no podman); subshell keeps the
             # cd local so the final cp below still resolves the relative output path
             ( cd "$tmp_context" && \\
@@ -125,7 +140,7 @@ def _htvend_image_impl(ctx):
                       build-img-with-proxy -f {dockerfile} . )""".format(
             lockfile_name = ctx.attr.lockfile_name,
             dockerfile = ctx.attr.dockerfile,
-            env_exports = build_env_exports(ctx.attr.env, ctx.attr.platforms),
+            env_exports = build_env_exports(direct_env, ctx.attr.platforms),
         )
         execution_requirements = {}
 
@@ -193,6 +208,11 @@ _htvend_image = rule(
         "lockfile_name": attr.string(default = "assets.json"),
         "dockerfile": attr.string(default = "Dockerfile"),
         "env": attr.string_dict(default = {}),
+        # buildah storage driver for the offline build (sets STORAGE_DRIVER). Empty ->
+        # per-mode default: direct/RBE mode uses "vfs" (needs no /dev/fuse on the worker);
+        # podman mode leaves it to the tool image (overlay + the --device /dev/fuse it
+        # passes). Set to "overlay" or "vfs" to override either mode.
+        "storage_driver": attr.string(default = ""),
         # os/arch list built into the manifest. Empty (default) -> just the host
         # architecture (see HOST_PLATFORM_SH); set it to build a multi-arch manifest.
         "platforms": attr.string_list(default = []),


### PR DESCRIPTION
The offline build's direct (RBE) mode now sets STORAGE_DRIVER=vfs by default, with a new `storage_driver` attribute to override it. vfs needs no /dev/fuse (overlay's fuse-overlayfs is what required the device), so an RBE worker no longer needs a fuse device passed through. Output images are byte-identical to the overlay build.

podman mode is unchanged (overlay + the --device /dev/fuse it already passes); it only sets STORAGE_DRIVER when the attribute is set explicitly.

A spike against bb-deployments mapped the resulting worker privilege floor and verified two reduced runner privilege sets end-to-end -- both drop /dev/fuse and produce the documented digest:
- Strategy P: SYS_ADMIN + apparmor=unconfined (default seccomp kept on)
- Strategy U: seccomp=unconfined + apparmor=unconfined (no SYS_ADMIN)

docs/bazel.md rewrites the RBE section around this: the custom image is normal; the real requirement is buildah's irreducible mount privilege, presented as a Strategy-P-vs-U tier matrix.